### PR TITLE
Add nats msg.Subject to context in Sub method

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -22,7 +22,9 @@ func (q *Queue) Sub(ctx context.Context, topic, channel string, sub Subscriber) 
 	// TODO is there anything we can do with the error
 	_, _ = q.client(ctx).QueueSubscribe(topic, channel, func(msg *nats.Msg) {
 		// TODO is there anything we can do with this error
-		_ = sub.Message(context.WithValue(q.t.Context(), "reply", msg.Reply), q.t, topic, channel, msg.Data)
+		thisCtx := context.WithValue(q.t.Context(), "reply", msg.Reply)
+		thisCtx = context.WithValue(thisCtx, "subject", msg.Subject)
+		_ = sub.Message(thisCtx, q.t, topic, channel, msg.Data)
 	})
 }
 

--- a/queue.go
+++ b/queue.go
@@ -10,10 +10,10 @@ import (
 // Queue abstracts the underlying message queue from microservices. We will use nsq for "native" deployments
 // but want to have the freedom of easily using a platform provided queue service if available.
 type Queue struct {
-	subs      []Subscriber
+	subs     []Subscriber
 	Client   *nats.Conn
-	t         *Teacup
-	producer  *Producer
+	t        *Teacup
+	producer *Producer
 }
 
 // Sub to an event topic and channel. The returned CancelFunc can be used to cancel the subscription.
@@ -44,12 +44,12 @@ func (q *Queue) client(ctx context.Context) *nats.Conn {
 		servers := q.t.ServiceAddrs(ctx, "nats", 4222)
 		addrs := make([]string, len(servers))
 		for i, s := range servers {
-			addrs[i] = "nats://"+s
+			addrs[i] = "nats://" + s
 		}
 		opts := nats.Options{
 			Servers: addrs,
 			ClosedCB: func(_ *nats.Conn) {
-				q.t.natsDone<-true
+				q.t.natsDone <- true
 			},
 		}
 		conn, err := opts.Connect()


### PR DESCRIPTION
This PR adds the `*nats.Msg.Subject` field to the context of `Sub` & runs a quick gofmt on `queue.go`.

The `msg.Subject` field of a nats message reveals the "actual" subject of a message when a wildcard subscription is made. If the subscription is made with a wildcard, the actual subject will be different than the subscribed subject, and we often want to extract the wildcarded field for processing.

For instance, if I subscribe to `auth.codes.*` and a message is published to `auth.codes.b2b4a086-daa2-4c93-b870-405e3a6152ad`, the `msg.Subject` will contain `auth.codes.b2b4a086-daa2-4c93-b870-405e3a6152ad`. This can be combined with the topic to extract the field of interest, in this case `b2b4a086-daa2-4c93-b870-405e3a6152ad`.

See https://github.com/nats-io/go-nats/blob/master/nats.go#L396 and the docs (https://docs.nats.io/developing-with-nats/receiving/wildcards)
> There is no special code to subscribe with a wildcard subject. Wildcards are a normal part of the subject name. However, it is a common technique to use the subject provided with the incoming message to determine what to do with the message. For example, you can subscribe using * and then act based on the actual subject.